### PR TITLE
Include `Accept` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+* Include `Accept` header in requests to JSON API
+
 ## 0.2.1
 
 * Return `online_booking_twilio_number` in stubbed response

--- a/lib/booking_locations/api.rb
+++ b/lib/booking_locations/api.rb
@@ -15,6 +15,7 @@ module BookingLocations
       {}.tap do |hash|
         hash[:read_timeout]   = read_timeout
         hash['Authorization'] = "Bearer #{bearer_token}" if bearer_token
+        hash['Accept'] = 'application/json'
       end
     end
 

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.3.0'.freeze
 end


### PR DESCRIPTION
Turns out when this isn't included, GDS-SSO doesn't regard the request as
API in nature, so doesn't attempt to authenticate with the bearer token and
instead bounces the request over into the usual oauth2 dance.