### PR TITLE
Add GlobalID support for serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+* Support GlobalID identification
+
 ## 0.3.0
 
 * Include `Accept` header in requests to JSON API

--- a/booking_locations.gemspec
+++ b/booking_locations.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.1'
+  spec.add_runtime_dependency 'globalid'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/booking_locations/location.rb
+++ b/lib/booking_locations/location.rb
@@ -1,9 +1,16 @@
 require 'ostruct'
+require 'global_id'
 
 module BookingLocations
   class Location
+    include GlobalID::Identification
+
     def initialize(data)
       @data = data
+    end
+
+    def self.find(id)
+      BookingLocations.find(id)
     end
 
     def id

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.4.0'.freeze
 end

--- a/spec/location_spec.rb
+++ b/spec/location_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe BookingLocations::Location do
 
   subject { described_class.new(data) }
 
+  it 'supports GlobalID serialization / deserialization' do
+    expect(described_class).to include(GlobalID::Identification)
+    expect(described_class).to respond_to(:find)
+  end
+
   it 'has an ID' do
     expect(subject.id).to eq('9d7c72fc-0c74-4418-8099-e1a4e704cb01')
   end


### PR DESCRIPTION
This allows us to serialize and deserialize locations, following the
GlobalID protocol. This means we can pass them around into background jobs,
mailers and the like.