### PR TITLE
Adds configurable caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+* Adds configurable caching for location responses
+
 ## 0.5.0
 
 * Return guider's name by ID

--- a/lib/booking_locations.rb
+++ b/lib/booking_locations.rb
@@ -2,19 +2,29 @@ require 'booking_locations/version'
 require 'booking_locations/api'
 require 'booking_locations/slot'
 require 'booking_locations/location'
+require 'booking_locations/null_cache'
 
 require 'active_support/core_ext/module/attribute_accessors'
 
 module BookingLocations
+  DEFAULT_TTL = 2 * 60 * 60 # 2 hours
+
   mattr_writer :api
+  mattr_writer :cache
 
   def self.api
     @@api ||= BookingLocations::Api.new
   end
 
-  def self.find(id)
-    api.get(id) do |response_hash|
-      Location.new(response_hash)
+  def self.cache
+    @@cache ||= BookingLocations::NullCache.new
+  end
+
+  def self.find(id, expires = DEFAULT_TTL)
+    cache.fetch(id, expires: expires) do
+      api.get(id) do |response_hash|
+        Location.new(response_hash)
+      end
     end
   end
 end

--- a/lib/booking_locations/null_cache.rb
+++ b/lib/booking_locations/null_cache.rb
@@ -1,0 +1,7 @@
+module BookingLocations
+  class NullCache
+    def fetch(*)
+      yield
+    end
+  end
+end

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end

--- a/spec/booking_locations_spec.rb
+++ b/spec/booking_locations_spec.rb
@@ -8,14 +8,24 @@ RSpec.describe BookingLocations do
       let(:api) { instance_double(BookingLocations::Api) }
       let(:id) { '9d7c72fc-0c74-4418-8099-e1a4e704cb01' }
       let(:response) { Hash.new }
+      let(:cache) { double }
+      let(:ttl) { BookingLocations::DEFAULT_TTL }
 
       before do
-        BookingLocations.api = api
+        BookingLocations.api   = api
+        BookingLocations.cache = cache
         allow(api).to receive(:get).with(id).and_yield(response)
+        allow(cache).to receive(:fetch).with(id, expires: ttl).and_yield
       end
 
       it 'returns the `Location`' do
         expect(BookingLocations.find(id)).to be_a(BookingLocations::Location)
+      end
+
+      it 'reads-through the cache' do
+        expect(cache).to receive(:fetch).with(id, expires: 10).and_yield
+
+        BookingLocations.find(id, 10)
       end
     end
   end


### PR DESCRIPTION
Defaults to a pass-through cache when unconfigured. When configured with
the `Rails.cache` it will cache the responses for the given ttl. This
defaults to two hours via `BookingLocations::DEFAULT_TTL`.