### PR TITLE
Use Rails' `NullStore` as a stand-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+* Replace our own null cache with Rails' `NullStore`
+
 ## 0.6.0
 
 * Adds configurable caching for location responses

--- a/lib/booking_locations.rb
+++ b/lib/booking_locations.rb
@@ -2,9 +2,9 @@ require 'booking_locations/version'
 require 'booking_locations/api'
 require 'booking_locations/slot'
 require 'booking_locations/location'
-require 'booking_locations/null_cache'
 
 require 'active_support/core_ext/module/attribute_accessors'
+require 'active_support/cache/null_store'
 
 module BookingLocations
   DEFAULT_TTL = 2 * 60 * 60 # 2 hours
@@ -17,7 +17,7 @@ module BookingLocations
   end
 
   def self.cache
-    @@cache ||= BookingLocations::NullCache.new
+    @@cache ||= ActiveSupport::Cache::NullStore.new
   end
 
   def self.find(id, expires = DEFAULT_TTL)

--- a/lib/booking_locations/null_cache.rb
+++ b/lib/booking_locations/null_cache.rb
@@ -1,7 +1,0 @@
-module BookingLocations
-  class NullCache
-    def fetch(*)
-      yield
-    end
-  end
-end

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.6.0'.freeze
+  VERSION = '0.6.1'.freeze
 end


### PR DESCRIPTION
We were previously using our own `NullCache` to pass-through when caching
was unconfigured. Since the other stores are mostly Rails provided - using
their `NullStore` means it's certain they quack the same.