### PR TITLE
Guard against location names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0
+
+* Guard against missing or outdated location names
+
 ## 0.7.0
 
 * Add stubbed responses for Taunton and children

--- a/lib/booking_locations/location.rb
+++ b/lib/booking_locations/location.rb
@@ -52,7 +52,8 @@ module BookingLocations
     end
 
     def name_for(location_id)
-      location_for(location_id).name
+      found = location_for(location_id)
+      found ? found.name : ''
     end
   end
 end

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.8.0'.freeze
 end

--- a/spec/location_spec.rb
+++ b/spec/location_spec.rb
@@ -84,6 +84,12 @@ RSpec.describe BookingLocations::Location do
         expect(subject.name_for('1d7c72fc-0c74-4418-8099-e1a4e704cb01')).to eq('Child CAB')
       end
     end
+
+    context 'with a non-existent location ID' do
+      it 'returns an empty string' do
+        expect(subject.name_for('deadbeef-dead-beef-beef-deadbeefdead')).to eq('')
+      end
+    end
   end
 
   describe '#guider_name_for' do


### PR DESCRIPTION
This can happen when the requesting application has a reference to an
outdated location.