### PR TITLE
Ensure correct cache expiry option is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+* Respect TTL options
+
 ## 0.9.0
 
 * Restructured slot nesting for locations

--- a/lib/booking_locations.rb
+++ b/lib/booking_locations.rb
@@ -21,7 +21,7 @@ module BookingLocations
   end
 
   def self.find(id, expires = DEFAULT_TTL)
-    cache.fetch(id, expires: expires) do
+    cache.fetch(id, expires_in: expires) do
       api.get(id) do |response_hash|
         Location.new(response_hash)
       end

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.9.0'.freeze
+  VERSION = '0.9.1'.freeze
 end

--- a/spec/booking_locations_spec.rb
+++ b/spec/booking_locations_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BookingLocations do
         BookingLocations.api = api
 
         allow(api).to receive(:get).with(id).and_yield(response)
-        allow(cache).to receive(:fetch).with(id, expires: ttl).and_yield
+        allow(cache).to receive(:fetch).with(id, expires_in: ttl).and_yield
       end
 
       it 'returns the `Location`' do
@@ -25,7 +25,7 @@ RSpec.describe BookingLocations do
       context 'when the cache store is configured' do
         it 'reads-through the cache' do
           with_cache(cache) do
-            expect(cache).to receive(:fetch).with(id, expires: 10).and_yield
+            expect(cache).to receive(:fetch).with(id, expires_in: 10).and_yield
 
             BookingLocations.find(id, 10)
           end


### PR DESCRIPTION
Since moving to redis-backed caches we noticed keys were no longer
respecting their given TTL. This change ensures the TTL is set and keys
expire on schedule when storing entries in the redis cache.