### PR TITLE
Prefix cache entries on writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.0
+
+* Add cache key namespacing / prefixing
+
 ## 0.10.0
 
 * Add `Location#hidden` flag and predicate

--- a/lib/booking_locations.rb
+++ b/lib/booking_locations.rb
@@ -7,6 +7,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/cache/null_store'
 
 module BookingLocations
+  DEFAULT_PREFIX = 'booking_locations:'
   DEFAULT_TTL = 2 * 60 * 60 # 2 hours
 
   mattr_writer :api
@@ -20,8 +21,8 @@ module BookingLocations
     @@cache ||= ActiveSupport::Cache::NullStore.new
   end
 
-  def self.find(id, expires = DEFAULT_TTL)
-    cache.fetch(id, expires_in: expires) do
+  def self.find(id, expires = DEFAULT_TTL, prefix = DEFAULT_PREFIX)
+    cache.fetch(prefix.concat(id), expires_in: expires) do
       api.get(id) do |response_hash|
         Location.new(response_hash)
       end

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.10.0'.freeze
+  VERSION = '0.11.0'.freeze
 end

--- a/spec/booking_locations_spec.rb
+++ b/spec/booking_locations_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe BookingLocations do
     context 'when the location is present' do
       let(:api) { instance_double(BookingLocations::Api) }
       let(:id) { '9d7c72fc-0c74-4418-8099-e1a4e704cb01' }
+      let(:prefixed_id) { BookingLocations::DEFAULT_PREFIX.concat(id) }
       let(:response) { Hash.new }
       let(:cache) { double }
       let(:ttl) { BookingLocations::DEFAULT_TTL }
@@ -15,7 +16,7 @@ RSpec.describe BookingLocations do
         BookingLocations.api = api
 
         allow(api).to receive(:get).with(id).and_yield(response)
-        allow(cache).to receive(:fetch).with(id, expires_in: ttl).and_yield
+        allow(cache).to receive(:fetch).with(prefixed_id, expires_in: ttl).and_yield
       end
 
       it 'returns the `Location`' do
@@ -25,7 +26,7 @@ RSpec.describe BookingLocations do
       context 'when the cache store is configured' do
         it 'reads-through the cache' do
           with_cache(cache) do
-            expect(cache).to receive(:fetch).with(id, expires_in: 10).and_yield
+            expect(cache).to receive(:fetch).with(prefixed_id, expires_in: 10).and_yield
 
             BookingLocations.find(id, 10)
           end


### PR DESCRIPTION
Applies a prefix / namespace to cache entries upon write. This allows us to
match on particular groups of keys collectively when invalidating entries
elsewhere.