### PR TITLE
Don't mutate cache keys when prefixing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.0
+
+* Don't mutate cache prefixes in place
+
 ## 0.12.0
 
 * Add ability to clear all prefixed cache entries

--- a/lib/booking_locations.rb
+++ b/lib/booking_locations.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/cache/null_store'
 
 module BookingLocations
-  DEFAULT_PREFIX = 'booking_locations:'
+  DEFAULT_PREFIX = 'booking_locations:'.freeze
   DEFAULT_TTL = 2 * 60 * 60 # 2 hours
 
   mattr_writer :api
@@ -21,15 +21,19 @@ module BookingLocations
     @@cache ||= ActiveSupport::Cache::NullStore.new
   end
 
-  def self.find(id, expires = DEFAULT_TTL, prefix = DEFAULT_PREFIX)
-    cache.fetch(prefix.concat(id), expires_in: expires) do
+  def self.find(id, expires = DEFAULT_TTL)
+    cache.fetch(cache_prefix(id), expires_in: expires) do
       api.get(id) do |response_hash|
         Location.new(response_hash)
       end
     end
   end
 
-  def self.clear_cache(prefix = DEFAULT_PREFIX)
-    cache.delete_matched(prefix.concat('*'))
+  def self.clear_cache
+    cache.delete_matched(cache_prefix('*'))
+  end
+
+  def self.cache_prefix(key)
+    DEFAULT_PREFIX.dup.concat(key)
   end
 end

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.12.0'.freeze
+  VERSION = '0.13.0'.freeze
 end

--- a/spec/booking_locations_spec.rb
+++ b/spec/booking_locations_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe BookingLocations do
 
     it 'delegates to the underlying cache store' do
       with_cache(cache) do
-        expect(cache).to receive(:delete_matched).with('bleh:*')
+        expect(cache).to receive(:delete_matched).with('booking_locations:*')
 
-        BookingLocations.clear_cache('bleh:')
+        BookingLocations.clear_cache
       end
     end
   end
@@ -19,7 +19,7 @@ RSpec.describe BookingLocations do
     context 'when the location is present' do
       let(:api) { instance_double(BookingLocations::Api) }
       let(:id) { '9d7c72fc-0c74-4418-8099-e1a4e704cb01' }
-      let(:prefixed_id) { BookingLocations::DEFAULT_PREFIX.concat(id) }
+      let(:prefixed_id) { BookingLocations.cache_prefix(id) }
       let(:response) { Hash.new }
       let(:cache) { double }
       let(:ttl) { BookingLocations::DEFAULT_TTL }


### PR DESCRIPTION
The cache keys were being mutated with `concat` and modifying the
underlying constant. This change addresses that bug but also removes the
default arguments for associated public API. On reflection these just
aren't necessary extension points.