### PR TITLE
Loosen Active Support dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.0
+
+* Loosen Active Support dependency
+
 ## 0.14.0
 
 * Include `online_booking_reply_to` in API response

--- a/booking_locations.gemspec
+++ b/booking_locations.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.1'
+  spec.add_runtime_dependency 'activesupport', '>= 4', '<= 6'
   spec.add_runtime_dependency 'globalid'
 
   spec.add_development_dependency 'bundler', '~> 1.12'

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.14.0'.freeze
+  VERSION = '0.15.0'.freeze
 end


### PR DESCRIPTION
This was blocking Rails upgrades for hosting applications.