### PR TITLE
Stop swallowing timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.20.0
+
+* Don't swallow API timeouts resulting in `nil` cache entries
+
 ## 0.19.0
 
 * Include `online_booking_weekends` in the response

--- a/lib/booking_locations/api.rb
+++ b/lib/booking_locations/api.rb
@@ -5,7 +5,7 @@ module BookingLocations
     def get(id)
       response = open("#{api_uri}/api/v1/booking_locations/#{id}.json", headers_and_options)
       yield JSON.parse(response.read)
-    rescue OpenURI::HTTPError, Net::ReadTimeout
+    rescue OpenURI::HTTPError
       nil
     end
 

--- a/lib/booking_locations/version.rb
+++ b/lib/booking_locations/version.rb
@@ -1,3 +1,3 @@
 module BookingLocations
-  VERSION = '0.19.0'.freeze
+  VERSION = '0.20.0'.freeze
 end


### PR DESCRIPTION
When the timeout is swallowed, we end up with cascading failures due to
`nil` cache entries for the given location. If API calls are causing
timeouts we ought to know about this, thus it should fail loudly. Clients
can retry until the request completes.